### PR TITLE
Remove AgentSubordinationRelation

### DIFF
--- a/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-keywords.xml
+++ b/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-keywords.xml
@@ -8,6 +8,11 @@
 		<Arcroles>
 			<Arcrole>isControlledBy</Arcrole>
 			<Arcrole>controls</Arcrole>
+			<!-- To be moved here if we want to generate an AgentControlRelation -->
+			<!--
+			<Arcrole currentEntityRole="source">isSuperiorOf</Arcrole>
+			<Arcrole currentEntityRole="target">isInferiorOf</Arcrole>
+			-->
 		</Arcroles>
 	</AgentControlRelation>
 	<LeadershipRelation>
@@ -28,12 +33,6 @@
 			<Arcrole>hasSubdivision</Arcrole>
 		</Arcroles>
 	</GroupSubdivisionRelation>
-	<AgentSubordinationRelation>
-		<Arcroles>
-			<Arcrole currentEntityRole="source">isSuperiorOf</Arcrole>
-			<Arcrole currentEntityRole="target">isInferiorOf</Arcrole>
-		</Arcroles>
-	</AgentSubordinationRelation>
 	<MembershipRelation>
 		<Arcroles>
 			<Arcrole currentEntityRole="target">personIsMemberOf</Arcrole>

--- a/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-keywords.xml
+++ b/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-keywords.xml
@@ -8,11 +8,9 @@
 		<Arcroles>
 			<Arcrole>isControlledBy</Arcrole>
 			<Arcrole>controls</Arcrole>
-			<!-- To be moved here if we want to generate an AgentControlRelation -->
-			<!--
+			<!-- From an associative relation config -->
 			<Arcrole currentEntityRole="source">isSuperiorOf</Arcrole>
 			<Arcrole currentEntityRole="target">isInferiorOf</Arcrole>
-			-->
 		</Arcroles>
 	</AgentControlRelation>
 	<LeadershipRelation>

--- a/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-relations.xslt
+++ b/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-relations.xslt
@@ -118,6 +118,16 @@
 			<isSourceOfProperty>rico:agentHasWorkRelation</isSourceOfProperty>
 			<label>Relation professionnelle (de travail)</label>
 		</WorkRelation>
+		<!-- Note how AgentControlRelation is present in both hierarchical and associative relation configs -->
+		<AgentControlRelation>
+			<baseType>rico:AgentHierarchicalRelation</baseType>
+			<extraType>https://www.ica.org/standards/RiC/ontology#AgentControlRelation</extraType>
+			<targetProperty>rico:agentControlRelationHasTarget</targetProperty>
+			<sourceProperty>rico:agentControlRelationHasSource</sourceProperty>
+			<isTargetOfProperty>rico:agentIsTargetOfAgentControlRelation</isTargetOfProperty>
+			<isSourceOfProperty>rico:agentIsSourceOfAgentControlRelation</isSourceOfProperty>
+			<label>Relation de contrôle</label>
+		</AgentControlRelation>
 	</xsl:variable>
 	
 	<!-- Determine the type of an associativeRelation; the type corresponds to the possible types in $ASSOCIATIVE_RELATION_CONFIG -->
@@ -127,6 +137,7 @@
 			<xsl:when test="eac2rico:specifiesLeadershipRelation(@xlink:arcrole)">LeadershipRelation</xsl:when>
 			<xsl:when test="eac2rico:specifiesWorkRelation(@xlink:arcrole)">WorkRelation</xsl:when>
 			<xsl:when test="eac2rico:specifiesMembershipRelation(@xlink:arcrole)">MembershipRelation</xsl:when>
+			<xsl:when test="eac2rico:specifiesAgentControlRelation(@xlink:arcrole)">AgentControlRelation</xsl:when>
 	       	<!-- If we detect a specific keyword in the description... -->
 	       	<xsl:when test="eac2rico:denotesLeadershipRelation(eac:descriptiveNote)">
 	       		<!-- ...read the description of the referenced entity... -->

--- a/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-relations.xslt
+++ b/ricoconverter/ricoconverter-convert/src/main/resources/xslt_eac/eac2rico-relations.xslt
@@ -98,15 +98,6 @@
 			<isSourceOfProperty>rico:personIsSourceOfLeadershipRelation</isSourceOfProperty>
 			<label>Relation de direction (leadership)</label>
 		</LeadershipRelation>
-		<AgentSubordinationRelation>
-			<baseType>rico:AgentHierarchicalRelation</baseType>
-			<extraType>https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation</extraType>
-			<targetProperty>rico:agentSubordinationRelationHasTarget</targetProperty>
-			<sourceProperty>rico:agentSubordinationRelationHasSource</sourceProperty>
-			<isTargetOfProperty>rico:personIsTargetOfAgentSubordinationRelation</isTargetOfProperty>
-			<isSourceOfProperty>rico:personIsSourceOfAgentSubordinationRelation</isSourceOfProperty>
-			<label>Relation hiérarchique (de subordination)</label>
-		</AgentSubordinationRelation>
 		<MembershipRelation>
 			<baseType>rico:MembershipRelation</baseType>
 			<!-- no extra type here -->
@@ -134,7 +125,6 @@
 		<xsl:param name="relation"  as="element()?"/>
 		<xsl:choose>
 			<xsl:when test="eac2rico:specifiesLeadershipRelation(@xlink:arcrole)">LeadershipRelation</xsl:when>
-			<xsl:when test="eac2rico:specifiesAgentSubordinationRelation(@xlink:arcrole)">AgentSubordinationRelation</xsl:when>
 			<xsl:when test="eac2rico:specifiesWorkRelation(@xlink:arcrole)">WorkRelation</xsl:when>
 			<xsl:when test="eac2rico:specifiesMembershipRelation(@xlink:arcrole)">MembershipRelation</xsl:when>
 	       	<!-- If we detect a specific keyword in the description... -->
@@ -402,11 +392,6 @@
 	<xsl:function name="eac2rico:specifiesLeadershipRelation" as="xs:boolean">
 		<xsl:param name="arcrole"  as="xs:string?" />
 		<xsl:sequence select="$KEYWORDS/AgentRelation/LeadershipRelation/Arcroles/Arcrole[text() = $arcrole] != ''" />
-	</xsl:function>
-	<!-- Tests if an xlink:arcrole attribute value indicates a AgentSubordinationRelation -->
-	<xsl:function name="eac2rico:specifiesAgentSubordinationRelation" as="xs:boolean">
-		<xsl:param name="arcrole"  as="xs:string?" />
-		<xsl:sequence select="$KEYWORDS/AgentRelation/AgentSubordinationRelation/Arcroles/Arcrole[text() = $arcrole] != ''" />
 	</xsl:function>
 	<!-- Tests if an xlink:arcrole attribute value indicates a WorkRelation -->
 	<xsl:function name="eac2rico:specifiesWorkRelation" as="xs:boolean">

--- a/ricoconverter/ricoconverter-convert/src/test/resources/eac2rico/_31cpfAgentSubordinationRelationWithArcrole/expected.xml
+++ b/ricoconverter/ricoconverter-convert/src/test/resources/eac2rico/_31cpfAgentSubordinationRelationWithArcrole/expected.xml
@@ -31,45 +31,27 @@
             <rico:type xml:lang="fr">nom d'agent : forme préférée</rico:type>
          </rico:AgentName>
       </rico:hasOrHadAgentName>
-      <rico:agentIsConnectedToAgentRelation rdf:resource="agentToAgentRelation/050571-111111"/>
-      <rico:agentIsConnectedToAgentRelation rdf:resource="agentToAgentRelation/050571-999999"/>
-      <!--
-      <rico:personIsSourceOfAgentSubordinationRelation rdf:resource="agentHierarchicalRelation/050571-111111"/>
-      <rico:personIsTargetOfAgentSubordinationRelation rdf:resource="agentHierarchicalRelation/999999-050571"/>
-      -->
+
+      <rico:agentIsSourceOfAgentControlRelation rdf:resource="agentHierarchicalRelation/050571-111111"/>
+      <rico:agentIsTargetOfAgentControlRelation rdf:resource="agentHierarchicalRelation/999999-050571"/>
    </rico:Agent>
 
-   <rico:AgentToAgentRelation rdf:about="agentToAgentRelation/050571-111111">
-      <rico:agentRelationConnects rdf:resource="agent/050571"/>
-      <rico:agentRelationConnects rdf:resource="agent/111111"/>
-      <rdfs:label xml:lang="fr">Relation associative entre "The entity" et "The inferior person"</rdfs:label>
-      <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a encadré "the inferior person" pendant 8 ans.</html:p></rico:descriptiveNote>
-   </rico:AgentToAgentRelation>
-   
-   <rico:AgentToAgentRelation rdf:about="agentToAgentRelation/050571-999999">
-      <rico:agentRelationConnects rdf:resource="agent/050571"/>
-      <rico:agentRelationConnects rdf:resource="agent/999999"/>
-      <rdfs:label xml:lang="fr">Relation associative entre "The entity" et "The superior person"</rdfs:label>
-      <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a été placée sous l'autorité hiérarchique de "the superior person" pendant trois ans.</html:p>
-      </rico:descriptiveNote>  
-   </rico:AgentToAgentRelation> 
-
-   <!--
    <rico:AgentHierarchicalRelation rdf:about="agentHierarchicalRelation/050571-111111">
-      <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
-      <rico:agentSubordinationRelationHasSource rdf:resource="agent/050571"/>
-      <rico:agentSubordinationRelationHasTarget rdf:resource="agent/111111"/>
-      <rdfs:label xml:lang="fr">Relation hiérarchique (de subordination) entre "The entity" et "The inferior person"</rdfs:label>
-      <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a encadré "the inferior person" pendant 8 ans.</html:p></rico:descriptiveNote>
+      <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
+      <rico:agentControlRelationHasSource rdf:resource="agent/050571"/>
+      <rico:agentControlRelationHasTarget rdf:resource="agent/111111"/>
+      <rdfs:label xml:lang="fr">Relation de contrôle entre "The entity" et "The inferior person"</rdfs:label>
+      <rico:descriptiveNote rdf:parseType="Literal">
+         <html:p xml:lang="fr">Cette personne a encadré "the inferior person" pendant 8 ans.</html:p>
+      </rico:descriptiveNote>
    </rico:AgentHierarchicalRelation>
-   
    <rico:AgentHierarchicalRelation rdf:about="agentHierarchicalRelation/999999-050571">
-      <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
-      <rico:agentSubordinationRelationHasSource rdf:resource="agent/999999"/>
-      <rico:agentSubordinationRelationHasTarget rdf:resource="agent/050571"/>
-      <rdfs:label xml:lang="fr">Relation hiérarchique (de subordination) entre "The superior person" et "The entity"</rdfs:label>
-      <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a été placée sous l'autorité hiérarchique de "the superior person" pendant trois ans.</html:p>
-      </rico:descriptiveNote>  
+      <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
+      <rico:agentControlRelationHasSource rdf:resource="agent/999999"/>
+      <rico:agentControlRelationHasTarget rdf:resource="agent/050571"/>
+      <rdfs:label xml:lang="fr">Relation de contrôle entre "The superior person" et "The entity"</rdfs:label>
+      <rico:descriptiveNote rdf:parseType="Literal">
+         <html:p xml:lang="fr">Cette personne a été placée sous l'autorité hiérarchique de "the superior person" pendant trois ans.</html:p>
+      </rico:descriptiveNote>
    </rico:AgentHierarchicalRelation>
-   -->
 </rdf:RDF>

--- a/ricoconverter/ricoconverter-convert/src/test/resources/eac2rico/_31cpfAgentSubordinationRelationWithArcrole/expected.xml
+++ b/ricoconverter/ricoconverter-convert/src/test/resources/eac2rico/_31cpfAgentSubordinationRelationWithArcrole/expected.xml
@@ -31,10 +31,30 @@
             <rico:type xml:lang="fr">nom d'agent : forme préférée</rico:type>
          </rico:AgentName>
       </rico:hasOrHadAgentName>
+      <rico:agentIsConnectedToAgentRelation rdf:resource="agentToAgentRelation/050571-111111"/>
+      <rico:agentIsConnectedToAgentRelation rdf:resource="agentToAgentRelation/050571-999999"/>
+      <!--
       <rico:personIsSourceOfAgentSubordinationRelation rdf:resource="agentHierarchicalRelation/050571-111111"/>
       <rico:personIsTargetOfAgentSubordinationRelation rdf:resource="agentHierarchicalRelation/999999-050571"/>
+      -->
    </rico:Agent>
+
+   <rico:AgentToAgentRelation rdf:about="agentToAgentRelation/050571-111111">
+      <rico:agentRelationConnects rdf:resource="agent/050571"/>
+      <rico:agentRelationConnects rdf:resource="agent/111111"/>
+      <rdfs:label xml:lang="fr">Relation associative entre "The entity" et "The inferior person"</rdfs:label>
+      <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a encadré "the inferior person" pendant 8 ans.</html:p></rico:descriptiveNote>
+   </rico:AgentToAgentRelation>
    
+   <rico:AgentToAgentRelation rdf:about="agentToAgentRelation/050571-999999">
+      <rico:agentRelationConnects rdf:resource="agent/050571"/>
+      <rico:agentRelationConnects rdf:resource="agent/999999"/>
+      <rdfs:label xml:lang="fr">Relation associative entre "The entity" et "The superior person"</rdfs:label>
+      <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a été placée sous l'autorité hiérarchique de "the superior person" pendant trois ans.</html:p>
+      </rico:descriptiveNote>  
+   </rico:AgentToAgentRelation> 
+
+   <!--
    <rico:AgentHierarchicalRelation rdf:about="agentHierarchicalRelation/050571-111111">
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
       <rico:agentSubordinationRelationHasSource rdf:resource="agent/050571"/>
@@ -51,4 +71,5 @@
       <rico:descriptiveNote  rdf:parseType="Literal"><html:p xml:lang="fr">Cette personne a été placée sous l'autorité hiérarchique de "the superior person" pendant trois ans.</html:p>
       </rico:descriptiveNote>  
    </rico:AgentHierarchicalRelation>
+   -->
 </rdf:RDF>


### PR DESCRIPTION
Fix #22 
Removes AgentSubordinationRelation - and removes "isSuperiorOf" and "isInferiorOf" in keywords detected in the XML.
To be discussed